### PR TITLE
getFetchEndpoint + isGithubOrganizationMember

### DIFF
--- a/__mocks__/github/rest.cjs
+++ b/__mocks__/github/rest.cjs
@@ -12,3 +12,5 @@ exports.createCommitStatus = jest.fn(({ target_url, state, context }) => {
   const id = Math.floor(Math.random() * 1000);
   return Promise.resolve({ status: 201, data: { url: `https://example.com/${id}`, state, target_url, context, id } });
 });
+
+exports.isGithubOrganizationMember = jest.fn(async () => Promise.resolve(false));

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,4 +1,4 @@
-export { GitHubConfigOpts } from "./github/types";
-export { getInstance } from "./github/setup";
+export { GitHubConfigOpts, GitHubInstance } from "./github/types";
+export { getInstance, getFetchEndpoint } from "./github/setup";
 export * from "./github/rest";
 export * from "./github/graphql";

--- a/src/github/rest.ts
+++ b/src/github/rest.ts
@@ -46,3 +46,20 @@ export const getRepository = makeMethod("repos", "get");
 export const getTag = makeMethod("git", "getTag");
 export const getTags = makePaginateMethod("GET /repos/{owner}/{repo}/tags");
 export const createCommitStatus = makeMethod("repos", "createCommitStatus");
+
+export async function isGithubOrganizationMember(
+  params: { org: string; username: string },
+  options?: GitHubOptions,
+): Promise<boolean> {
+  const { octokit } = await resolveSetup(options);
+  try {
+    const res = await octokit.orgs.checkMembershipForUser(params);
+    // Somehow, TS thinks that res.status can be only 302, but in reality, it can be anything
+    return (res.status as number) === 204;
+  } catch (e) {
+    if (e.status === 404) {
+      return false;
+    }
+    throw e;
+  }
+}

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -3,7 +3,7 @@ import { Octokit } from "@octokit/rest";
 import { BaseOptions } from "src/types";
 
 export type GitHubOptions = BaseOptions & {
-  octokitInstance?: Octokit;
+  octokitInstance?: GitHubInstance;
 };
 
 type GitHubConfigBaseOpts = {
@@ -29,3 +29,5 @@ type GitHubConfigTokenAuthOpts = GitHubConfigBaseOpts & {
 };
 
 export type GitHubConfigOpts = GitHubConfigAppAuthOpts | GitHubConfigInstallationAuthOpts | GitHubConfigTokenAuthOpts;
+
+export type GitHubInstance = Octokit & { token: string };


### PR DESCRIPTION
getFetchEndpoint is a method to get authorised git fetch using auth
token.
To get it working, special GitHubInstance type is now exported, which
holds auth token as well as an instance of Octokit.
