### PR TITLE
GitHub integration update

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ All integrations are unified under similar API, with following rules in mind:
 * All retry / rate-limiting logic should also be implemented in this module.
 
 #### Using mocks and fixtures
+
 ```ts
 // module.ts
 import { github } from "opstooling-integrations";
@@ -22,6 +23,7 @@ export async function foo() {
   await github.createCommitStatus({...});
 }
 ```
+
 ```ts
 // module.spec.ts
 import { describe, expect, it, jest } from "@jest/globals";
@@ -46,13 +48,35 @@ describe("foo", () => {
 
 #### Configuration
 
-| Environment variable   | Option for getInstance() | Description                                                       | Required?                                      | Default value            |
-|------------------------|--------------------------|-------------------------------------------------------------------|------------------------------------------------|--------------------------|
-| GITHUB_AUTH_TYPE       | authType                 | How to authorize in GitHub. Can be `token`, `app`, `installation` | no                                             | `token`                  |
-| GITHUB_APP_ID          | appId                    | GitHub app ID                                                     | yes, if `authType` is `app`, or `installation` | -                        |
-| GITHUB_CLIENT_ID       | clientId                 | GitHub client ID                                                  | yes, if `authType` is `app` or `installation`                   | -                        |
-| GITHUB_CLIENT_SECRET   | clientSecret             | GitHub client secret                                              | yes, if `authType` is `app` or `installation`                    | -                        |
-| GITHUB_PRIVATE_KEY     | privateKey               | GitHub app private key                                            | yes, if `authType` is `app` or `installation`                    | -                        |
-| GITHUB_TOKEN           | authToken                | GitHub auth token. Can be personal, oauth, etc.                   | yes, if `authType` is `token`                  | -                        |
-| GITHUB_INSTALLATION_ID | installationId           | GitHub app installation id                                        | if `authType` is `installation`                | -                        |
-| GITHUB_BASE_URL        | baseUrl                  | API endpoint URL                                                  | no                                             | `https://api.github.com` |
+Four auth types are supported: `app`, `installation`, `oauth`, and `token`.
+
+###### `app` auth
+
+Non-installation auth type for GitHub Apps. Using this means that org/repo permissions aren't accessible.  
+Requires `appId` and `privateKey`.
+
+###### `installation` auth
+
+This type is used to authorize requests for specific org/repo application installation. Requires `installationId`,
+which can be resolved using `app` auth. If app expected to have only one installation, then it can be configured through
+environment. Otherwise, use `github.getInstance` and pass the instance further.  
+Requires `appId`, `privateKey` and `installationId`.
+
+###### `oauth` auth
+
+This auth type requires `clientId` and `clientSecret`, and provides classic OAuth for GitHub Apps.
+
+###### `token` auth
+
+Simplest of all, requires only `token`, works for personal tokens or oauth tokens.
+
+| Environment variable                            | Option for getInstance() | Description                                                                             | Required?                                      | Default value            |
+|-------------------------------------------------|--------------------------|-----------------------------------------------------------------------------------------|------------------------------------------------|--------------------------|
+| GITHUB_AUTH_TYPE                                | authType                 | `app`, `token`, `installation`, or `oauth`                                              | no                                             | `token`                  |
+| GITHUB_APP_ID                                   | appId                    | GitHub app ID                                                                           | yes, if `authType` is `app`, or `installation` | -                        |
+| GITHUB_CLIENT_ID                                | clientId                 | GitHub client ID                                                                        | yes, if `authType` is `oauth`                  | -                        |
+| GITHUB_CLIENT_SECRET                            | clientSecret             | GitHub client secret                                                                    | yes, if `authType` is `oauth`                  | -                        |
+| GITHUB_PRIVATE_KEY or GITHUB_PRIVATE_KEY_BASE64 | privateKey               | GitHub app private key. <br/>Use GITHUB_PRIVATE_KEY_BASE64 to curcumvent newline issues | yes, if `authType` is `app` or `installation`  | -                        |
+| GITHUB_TOKEN                                    | authToken                | GitHub auth token. Can be personal, oauth, etc.                                         | yes, if `authType` is `token`                  | -                        |
+| GITHUB_INSTALLATION_ID                          | installationId           | GitHub app installation id                                                              | if `authType` is `installation`                | -                        |
+| GITHUB_BASE_URL                                 | baseUrl                  | API endpoint URL                                                                        | no                                             | `https://api.github.com` |

--- a/__mocks__/github/rest.cjs
+++ b/__mocks__/github/rest.cjs
@@ -12,6 +12,14 @@ exports.createCommitStatus = jest.fn(({ target_url, state, context }) => {
   const id = Math.floor(Math.random() * 1000);
   return Promise.resolve({ status: 201, data: { url: `https://example.com/${id}`, state, target_url, context, id } });
 });
+exports.createComment = jest.fn(({ owner, repo, issue_number, body }) => {
+  const id = Math.floor(Math.random() * 1000);
+  return Promise.resolve({
+    status: 201,
+    data: { url: `https://example.com/repos/${owner}/${repo}/issues/${issue_number}/comments/${id}`, body, id },
+  });
+});
+exports.getRepoInstallation = jest.fn(async () => Promise.reject({ status: 404, message: "Not found" }));
 
 exports.isGithubOrganizationMember = jest.fn(async () => Promise.resolve(false));
 exports.isGithubTeamMember = jest.fn(async () => Promise.resolve(false));

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@octokit/auth-app": "^4.0.7",
+    "@octokit/auth-oauth-app": "^5.0.4",
     "@octokit/core": "^4.1.0",
     "@octokit/plugin-paginate-rest": "^5.0.1",
     "@octokit/plugin-throttling": "^4.3.2",

--- a/src/github/rest.ts
+++ b/src/github/rest.ts
@@ -38,6 +38,7 @@ function makePaginateMethod<R extends keyof PaginatingEndpoints>(route: R) {
 }
 
 export const getAppInstallations = makePaginateMethod("GET /app/installations");
+export const getRepoInstallation = makeMethod("apps", "getRepoInstallation");
 export const getBranches = makePaginateMethod("GET /repos/{owner}/{repo}/branches");
 export const getBranch = makeMethod("repos", "getBranch");
 export const getPullRequest = makeMethod("pulls", "get");
@@ -46,6 +47,7 @@ export const getRepository = makeMethod("repos", "get");
 export const getTag = makeMethod("git", "getTag");
 export const getTags = makePaginateMethod("GET /repos/{owner}/{repo}/tags");
 export const createCommitStatus = makeMethod("repos", "createCommitStatus");
+export const createComment = makeMethod("issues", "createComment");
 
 export async function isGithubOrganizationMember(
   params: { org: string; username: string },

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -13,14 +13,20 @@ type GitHubConfigBaseOpts = {
 type GitHubConfigAppAuthOpts = GitHubConfigBaseOpts & {
   authType: "app";
   appId: string;
-  clientId: string;
-  clientSecret: string;
   privateKey: string;
 };
 
-type GitHubConfigInstallationAuthOpts = Omit<GitHubConfigAppAuthOpts, "authType"> & {
+type GitHubConfigInstallationPrivkeyAuthOpts = GitHubConfigBaseOpts & {
   authType: "installation";
+  appId: string;
+  privateKey: string;
   installationId: string;
+};
+
+type GitHubConfigInstallationOAuthOpts = GitHubConfigBaseOpts & {
+  authType: "oauth";
+  clientId: string;
+  clientSecret: string;
 };
 
 type GitHubConfigTokenAuthOpts = GitHubConfigBaseOpts & {
@@ -28,6 +34,10 @@ type GitHubConfigTokenAuthOpts = GitHubConfigBaseOpts & {
   authToken: string;
 };
 
-export type GitHubConfigOpts = GitHubConfigAppAuthOpts | GitHubConfigInstallationAuthOpts | GitHubConfigTokenAuthOpts;
+export type GitHubConfigOpts =
+  | GitHubConfigAppAuthOpts
+  | GitHubConfigInstallationPrivkeyAuthOpts
+  | GitHubConfigInstallationOAuthOpts
+  | GitHubConfigTokenAuthOpts;
 
 export type GitHubInstance = Octokit & { token: string };

--- a/src/schemas/GitHubConfigEnvSchema.ts
+++ b/src/schemas/GitHubConfigEnvSchema.ts
@@ -6,18 +6,26 @@ export const GitHubAppAuthSchema = GitHubConfigEnvBaseSchema.concat(
   Joi.object({
     GITHUB_AUTH_TYPE: Joi.string().allow("app").required(),
     GITHUB_APP_ID: Joi.string().pattern(/\d+/).required(),
-    GITHUB_CLIENT_ID: Joi.string().required(),
-    GITHUB_CLIENT_SECRET: Joi.string().required(),
     GITHUB_PRIVATE_KEY: Joi.string().required(),
   }),
 ).meta({ className: "GitHubAppAuthEnv" });
 
-export const GitHubAppInstallationAuthSchema = GitHubAppAuthSchema.concat(
+export const GitHubAppInstallationAuthSchema = GitHubConfigEnvBaseSchema.concat(
   Joi.object({
     GITHUB_AUTH_TYPE: Joi.string().allow(Joi.override, "installation").required(),
+    GITHUB_APP_ID: Joi.string().pattern(/\d+/).required(),
+    GITHUB_PRIVATE_KEY: Joi.string().required(),
     GITHUB_INSTALLATION_ID: Joi.string().required(),
   }),
 ).meta({ className: "GitHubAppInstallationAuthEnv" });
+
+export const GitHubAppOAuthSchema = GitHubConfigEnvBaseSchema.concat(
+  Joi.object({
+    GITHUB_AUTH_TYPE: Joi.string().allow(Joi.override, "oauth").required(),
+    GITHUB_CLIENT_ID: Joi.string().required(),
+    GITHUB_CLIENT_SECRET: Joi.string().required(),
+  }),
+).meta({ className: "GitHubAppOAuthEnv" });
 
 export const GitHubTokenAuthSchema = GitHubConfigEnvBaseSchema.concat(
   Joi.object({ GITHUB_AUTH_TYPE: Joi.string().allow("token"), GITHUB_TOKEN: Joi.string().required() }),

--- a/src/types/generated/GitHubConfigEnvSchema.js.ts
+++ b/src/types/generated/GitHubConfigEnvSchema.js.ts
@@ -7,8 +7,6 @@ export interface GitHubAppAuthEnv {
   GITHUB_APP_ID: string;
   GITHUB_AUTH_TYPE: "app";
   GITHUB_BASE_URL?: string;
-  GITHUB_CLIENT_ID: string;
-  GITHUB_CLIENT_SECRET: string;
   GITHUB_PRIVATE_KEY: string;
 }
 
@@ -16,10 +14,15 @@ export interface GitHubAppInstallationAuthEnv {
   GITHUB_APP_ID: string;
   GITHUB_AUTH_TYPE: "installation";
   GITHUB_BASE_URL?: string;
-  GITHUB_CLIENT_ID: string;
-  GITHUB_CLIENT_SECRET: string;
   GITHUB_INSTALLATION_ID: string;
   GITHUB_PRIVATE_KEY: string;
+}
+
+export interface GitHubAppOAuthEnv {
+  GITHUB_AUTH_TYPE: "oauth";
+  GITHUB_BASE_URL?: string;
+  GITHUB_CLIENT_ID: string;
+  GITHUB_CLIENT_SECRET: string;
 }
 
 export interface GitHubTokenAuthEnv {

--- a/src/types/generated/index.ts
+++ b/src/types/generated/index.ts
@@ -3,4 +3,4 @@
  * Do not modify this file manually
  */
 
-export * from "./GitHubConfigEnv";
+export * from "./GitHubConfigEnvSchema.js";

--- a/yarn.lock
+++ b/yarn.lock
@@ -317,7 +317,7 @@
     universal-github-app-jwt "^1.0.1"
     universal-user-agent "^6.0.0"
 
-"@octokit/auth-oauth-app@^5.0.0":
+"@octokit/auth-oauth-app@^5.0.0", "@octokit/auth-oauth-app@^5.0.4":
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/@octokit/auth-oauth-app/-/auth-oauth-app-5.0.4.tgz#ebd9a38f75381093d1a5e08e05b70b94f0918277"
   integrity sha512-zlWuii5hAN50vsV6SJC+uIJ7SMhyWjQMEmKJQxkmNDlieE9LjnkZnbOjqRsfcG7VO7WTl4K8ccpo/3A7Kdpmrw==


### PR DESCRIPTION
1. Fixed auth options: both in terms of which auth types are used for
what, and which options are required for each type
2. Supported setting private key from GITHUB_PRIVATE_KEY_BASE64, to get
around issues when passing newlines in environment
3. New methods: getRepoInstallation and createComment
