### PR TITLE
getFetchEndpoint and removal of `oauth` authType

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ describe("foo", () => {
 
 #### Configuration
 
-Four auth types are supported: `app`, `installation`, `oauth`, and `token`.
+Four auth types are supported: `app`, `installation`, and `token`.
 
 ###### `app` auth
 
@@ -62,20 +62,14 @@ which can be resolved using `app` auth. If app expected to have only one install
 environment. Otherwise, use `github.getInstance` and pass the instance further.  
 Requires `appId`, `privateKey` and `installationId`.
 
-###### `oauth` auth
-
-This auth type requires `clientId` and `clientSecret`, and provides classic OAuth for GitHub Apps.
-
 ###### `token` auth
 
 Simplest of all, requires only `token`, works for personal tokens or oauth tokens.
 
 | Environment variable                            | Option for getInstance() | Description                                                                             | Required?                                      | Default value            |
 |-------------------------------------------------|--------------------------|-----------------------------------------------------------------------------------------|------------------------------------------------|--------------------------|
-| GITHUB_AUTH_TYPE                                | authType                 | `app`, `token`, `installation`, or `oauth`                                              | no                                             | `token`                  |
+| GITHUB_AUTH_TYPE                                | authType                 | `app`, `token`, `installation`                                                          | no                                             | `token`                  |
 | GITHUB_APP_ID                                   | appId                    | GitHub app ID                                                                           | yes, if `authType` is `app`, or `installation` | -                        |
-| GITHUB_CLIENT_ID                                | clientId                 | GitHub client ID                                                                        | yes, if `authType` is `oauth`                  | -                        |
-| GITHUB_CLIENT_SECRET                            | clientSecret             | GitHub client secret                                                                    | yes, if `authType` is `oauth`                  | -                        |
 | GITHUB_PRIVATE_KEY or GITHUB_PRIVATE_KEY_BASE64 | privateKey               | GitHub app private key. <br/>Use GITHUB_PRIVATE_KEY_BASE64 to curcumvent newline issues | yes, if `authType` is `app` or `installation`  | -                        |
 | GITHUB_TOKEN                                    | authToken                | GitHub auth token. Can be personal, oauth, etc.                                         | yes, if `authType` is `token`                  | -                        |
 | GITHUB_INSTALLATION_ID                          | installationId           | GitHub app installation id                                                              | if `authType` is `installation`                | -                        |

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@octokit/auth-app": "^4.0.7",
-    "@octokit/auth-oauth-app": "^5.0.4",
     "@octokit/core": "^4.1.0",
     "@octokit/plugin-paginate-rest": "^6.0.0",
     "@octokit/plugin-throttling": "^4.3.2",

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -23,12 +23,6 @@ type GitHubConfigInstallationPrivkeyAuthOpts = GitHubConfigBaseOpts & {
   installationId: string;
 };
 
-type GitHubConfigInstallationOAuthOpts = GitHubConfigBaseOpts & {
-  authType: "oauth";
-  clientId: string;
-  clientSecret: string;
-};
-
 type GitHubConfigTokenAuthOpts = GitHubConfigBaseOpts & {
   authType: "token";
   authToken: string;
@@ -37,7 +31,15 @@ type GitHubConfigTokenAuthOpts = GitHubConfigBaseOpts & {
 export type GitHubConfigOpts =
   | GitHubConfigAppAuthOpts
   | GitHubConfigInstallationPrivkeyAuthOpts
-  | GitHubConfigInstallationOAuthOpts
   | GitHubConfigTokenAuthOpts;
 
-export type GitHubInstance = Octokit & { token: string };
+export type GitHubInstance = Octokit &
+  (
+    | {
+        authType: "installation" | "token";
+        token: string;
+      }
+    | {
+        authType: "app";
+      }
+  );

--- a/src/schemas/GitHubConfigEnvSchema.ts
+++ b/src/schemas/GitHubConfigEnvSchema.ts
@@ -19,14 +19,6 @@ export const GitHubAppInstallationAuthSchema = GitHubConfigEnvBaseSchema.concat(
   }),
 ).meta({ className: "GitHubAppInstallationAuthEnv" });
 
-export const GitHubAppOAuthSchema = GitHubConfigEnvBaseSchema.concat(
-  Joi.object({
-    GITHUB_AUTH_TYPE: Joi.string().allow(Joi.override, "oauth").required(),
-    GITHUB_CLIENT_ID: Joi.string().required(),
-    GITHUB_CLIENT_SECRET: Joi.string().required(),
-  }),
-).meta({ className: "GitHubAppOAuthEnv" });
-
 export const GitHubTokenAuthSchema = GitHubConfigEnvBaseSchema.concat(
   Joi.object({ GITHUB_AUTH_TYPE: Joi.string().allow("token"), GITHUB_TOKEN: Joi.string().required() }),
 ).meta({ className: "GitHubTokenAuthEnv" });

--- a/src/types/generated/GitHubConfigEnvSchema.js.ts
+++ b/src/types/generated/GitHubConfigEnvSchema.js.ts
@@ -18,13 +18,6 @@ export interface GitHubAppInstallationAuthEnv {
   GITHUB_PRIVATE_KEY: string;
 }
 
-export interface GitHubAppOAuthEnv {
-  GITHUB_AUTH_TYPE: "oauth";
-  GITHUB_BASE_URL?: string;
-  GITHUB_CLIENT_ID: string;
-  GITHUB_CLIENT_SECRET: string;
-}
-
 export interface GitHubTokenAuthEnv {
   GITHUB_AUTH_TYPE?: "token";
   GITHUB_BASE_URL?: string;


### PR DESCRIPTION
After another round of close inspection and an outage during the
deployment of gitspiegel, here are the findings:
1. `oauth` authType was deeply incorrect, as it's not really possible to
use it in the same way as other auth types.
2. Getting token for fetching wouldn't work with "app" authType.

Thus, removing `oauth` authType together with its parameters, and
allowing `getFetchEndpoint` only for `token` and `installation`
authTypes.

I tried to make it forbidden via static typing, however that proved
itself being a bit too complex, so runtime check it is then.
